### PR TITLE
remove pid file before executing

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -37,4 +37,6 @@ fi
 
 htpasswd -cb /etc/squid/passwd "${USERNAME}" "${PASSWORD}"
 
+rm -f /run/squid.pid
+
 exec "$(which squid)" -NYCd 1


### PR DESCRIPTION
in my case, pid files would be left around in the container and prevent the app from restarting

I'm not sure *exactly* why this was happening, but I think it's because of a mass restart/shutdown of containers on the machine.